### PR TITLE
Changed NetBuffer bool write to return bool value

### DIFF
--- a/Lidgren.Network/NetBuffer.Write.cs
+++ b/Lidgren.Network/NetBuffer.Write.cs
@@ -83,12 +83,15 @@ namespace Lidgren.Network
 
 		/// <summary>
 		/// Writes a boolean value using 1 bit
+        /// <returns>value written</returns>
 		/// </summary>
-		public void Write(bool value)
+		public bool Write(bool value)
 		{
 			EnsureBufferSize(m_bitLength + 1);
 			NetBitWriter.WriteByte((value ? (byte)1 : (byte)0), 1, m_data, m_bitLength);
 			m_bitLength += 1;
+
+		    return value;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Allows writing easier branching server code by eliminating redundant
checks

Instead of writing:

```
buffer.write(player != null);
if(player != null)
{
    buffer.write(player.name);
}
```

You can write:

```
if(buffer.write(player != null))
{
    buffer.write(player.name);
}
```
