### PR TITLE
UPnP discovery timeout

### DIFF
--- a/Lidgren.Network/NetPeer.Internal.cs
+++ b/Lidgren.Network/NetPeer.Internal.cs
@@ -389,6 +389,9 @@ namespace Lidgren.Network
 				}
 			}
 
+            if (m_upnp != null)
+                m_upnp.CheckForDiscoveryTimeout();
+
 			//
 			// read from socket
 			//


### PR DESCRIPTION
The UPnP discovery process was not timing out if a discovery response was not received (e.g. if UPnP was disabled on your router). So the status would remain on "Discovering" forever and never change to "NotAvailable".

This pull request resolves this issue. Let me know if you have any questions or need anything else.

PS. I would have used the new C# 6 null-conditional operator (e.g. m_upnp?.CheckForDiscoveryTimeout()), but I wasn't sure if you were using Visual Studio 2015 yet.