### PR TITLE
Fixed sublte bug in ReadUInt64(int) and PeekUInt64(int)

### DIFF
--- a/Lidgren.Network/NetBuffer.Peek.cs
+++ b/Lidgren.Network/NetBuffer.Peek.cs
@@ -237,7 +237,7 @@ namespace Lidgren.Network
 			else
 			{
 				retval = NetBitWriter.ReadUInt32(m_data, 32, m_readPosition);
-				retval |= NetBitWriter.ReadUInt32(m_data, numberOfBits - 32, m_readPosition) << 32;
+				retval |= (UInt64)NetBitWriter.ReadUInt32(m_data, numberOfBits - 32, m_readPosition + 32) << 32;
 			}
 			return retval;
 		}

--- a/Lidgren.Network/NetBuffer.Read.cs
+++ b/Lidgren.Network/NetBuffer.Read.cs
@@ -315,7 +315,7 @@ namespace Lidgren.Network
 			else
 			{
 				retval = NetBitWriter.ReadUInt32(m_data, 32, m_readPosition);
-				retval |= NetBitWriter.ReadUInt32(m_data, numberOfBits - 32, m_readPosition) << 32;
+				retval |= (UInt64)NetBitWriter.ReadUInt32(m_data, numberOfBits - 32, m_readPosition + 32) << 32;
 			}
 			m_readPosition += numberOfBits;
 			return retval;

--- a/UnitTests/ReadWriteTests.cs
+++ b/UnitTests/ReadWriteTests.cs
@@ -43,6 +43,7 @@ namespace UnitTests
 			msg.Write("duke of earl");
 			msg.Write((byte)43);
 			msg.Write((ushort)44);
+			msg.Write(UInt64.MaxValue, 64);
 			msg.Write(true);
 
 			msg.WritePadBits();
@@ -83,8 +84,13 @@ namespace UnitTests
 				throw new NetException("Read/write failure");
 
 			bdr.Append(inc.ReadUInt16());
+
+			if (inc.PeekUInt64(64) != UInt64.MaxValue)
+				throw new NetException("Read/write failure");
+
+			bdr.Append(inc.ReadUInt64());
 			bdr.Append(inc.ReadBoolean());
-			
+		
 			inc.SkipPadBits();
 
 			bdr.Append(inc.ReadSingle());
@@ -96,7 +102,7 @@ namespace UnitTests
 			bdr.Append(inc.ReadVariableUInt32());
 			bdr.Append(inc.ReadVariableInt64());
 
-			if (bdr.ToString().Equals("False-342duke of earl4344True56784521159980224614-4747000048-49"))
+			if (bdr.ToString().Equals("False-342duke of earl434418446744073709551615True56784521159980224614-4747000048-49"))
 				Console.WriteLine("Read/write tests OK");
 			else
 				throw new NetException("Read/write tests FAILED!");


### PR DESCRIPTION
Peek and Read for UInt64, with numberBits as parameter, in NetBuffer breaks when reading values above 32 bits. This is due to reading the same position twice, and not casting the second read to UInt64, breaking the bit shift.

Added tests that reproduce the bug which fails before the fix and passes after the fix.

(This is my first pull request, let me know if I did it incorrectly).