### PR TITLE
Implement IPv6 Dual Mode

### DIFF
--- a/Lidgren.Network/NetPeer.Internal.cs
+++ b/Lidgren.Network/NetPeer.Internal.cs
@@ -124,7 +124,7 @@ namespace Lidgren.Network
 			m_lastSocketBind = now;
 
 			if (m_socket == null)
-				m_socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+				m_socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);
 
 			if (reBind)
 				m_socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, (int)1); 
@@ -133,7 +133,9 @@ namespace Lidgren.Network
 			m_socket.SendBufferSize = m_configuration.SendBufferSize;
 			m_socket.Blocking = false;
 
-			var ep = (EndPoint)new NetEndPoint(m_configuration.LocalAddress, reBind ? m_listenPort : m_configuration.Port);
+		    m_socket.DualMode = true;
+
+			var ep = (EndPoint)new NetEndPoint(m_configuration.LocalAddress.MapToIPv6(), reBind ? m_listenPort : m_configuration.Port);
 			m_socket.Bind(ep);
 
 			try

--- a/Lidgren.Network/NetPeer.LatencySimulation.cs
+++ b/Lidgren.Network/NetPeer.LatencySimulation.cs
@@ -135,6 +135,9 @@ namespace Lidgren.Network
 		internal bool ActuallySendPacket(byte[] data, int numBytes, NetEndPoint target, out bool connectionReset)
 		{
 			connectionReset = false;
+
+		    target = NetUtility.MapToIPv6(target);
+
 			IPAddress ba = default(IPAddress);
 			try
 			{

--- a/Lidgren.Network/NetPeer.cs
+++ b/Lidgren.Network/NetPeer.cs
@@ -121,7 +121,7 @@ namespace Lidgren.Network
 			m_connections = new List<NetConnection>();
 			m_connectionLookup = new Dictionary<NetEndPoint, NetConnection>();
 			m_handshakes = new Dictionary<NetEndPoint, NetConnection>();
-			m_senderRemote = (EndPoint)new NetEndPoint(IPAddress.Any, 0);
+			m_senderRemote = (EndPoint)new NetEndPoint(IPAddress.IPv6Any, 0);
 			m_status = NetPeerStatus.NotRunning;
 			m_receivedFragmentGroups = new Dictionary<NetConnection, Dictionary<int, ReceivedFragmentGroup>>();	
 		}
@@ -275,6 +275,9 @@ namespace Lidgren.Network
 		{
 			if (remoteEndPoint == null)
 				throw new ArgumentNullException("remoteEndPoint");
+
+
+		    remoteEndPoint = NetUtility.MapToIPv6(remoteEndPoint);
 
 			lock (m_connections)
 			{

--- a/Lidgren.Network/NetPeerConfiguration.cs
+++ b/Lidgren.Network/NetPeerConfiguration.cs
@@ -93,7 +93,7 @@ namespace Lidgren.Network
 			//
 			m_disabledTypes = NetIncomingMessageType.ConnectionApproval | NetIncomingMessageType.UnconnectedData | NetIncomingMessageType.VerboseDebugMessage | NetIncomingMessageType.ConnectionLatencyUpdated | NetIncomingMessageType.NatIntroductionSuccess;
 			m_networkThreadName = "Lidgren network thread";
-			m_localAddress = IPAddress.Any;
+			m_localAddress = IPAddress.IPv6Any;
 			m_broadcastAddress = IPAddress.Broadcast;
 			var ip = NetUtility.GetBroadcastAddress();
 			if (ip != null)
@@ -327,10 +327,10 @@ namespace Lidgren.Network
 			}
 		}
 
-		/// <summary>
-		/// Gets or sets the local ip address to bind to. Defaults to IPAddress.Any. Cannot be changed once NetPeer is initialized.
-		/// </summary>
-		public IPAddress LocalAddress
+        /// <summary>
+        /// Gets or sets the local ip address to bind to. Defaults to <see cref="IPAddress.IPv6Any"/>. Cannot be changed once NetPeer is initialized.
+        /// </summary>
+        public IPAddress LocalAddress
 		{
 			get { return m_localAddress; }
 			set

--- a/Lidgren.Network/NetUtility.cs
+++ b/Lidgren.Network/NetUtility.cs
@@ -96,7 +96,7 @@ namespace Lidgren.Network
 			NetAddress ipAddress = null;
 			if (NetAddress.TryParse(ipOrHost, out ipAddress))
 			{
-				if (ipAddress.AddressFamily == AddressFamily.InterNetwork)
+				if (ipAddress.AddressFamily == AddressFamily.InterNetwork || ipAddress.AddressFamily == AddressFamily.InterNetworkV6)
 				{
 					callback(ipAddress);
 					return;
@@ -137,7 +137,7 @@ namespace Lidgren.Network
 					// check each entry for a valid IP address
 					foreach (var ipCurrent in entry.AddressList)
 					{
-						if (ipCurrent.AddressFamily == AddressFamily.InterNetwork)
+						if (ipCurrent.AddressFamily == AddressFamily.InterNetwork || ipAddress.AddressFamily == AddressFamily.InterNetworkV6)
 						{
 							callback(ipCurrent);
 							return;
@@ -174,9 +174,9 @@ namespace Lidgren.Network
 			NetAddress ipAddress = null;
 			if (NetAddress.TryParse(ipOrHost, out ipAddress))
 			{
-				if (ipAddress.AddressFamily == AddressFamily.InterNetwork)
+				if (ipAddress.AddressFamily == AddressFamily.InterNetwork || ipAddress.AddressFamily == AddressFamily.InterNetworkV6)
 					return ipAddress;
-				throw new ArgumentException("This method will not currently resolve other than ipv4 addresses");
+				throw new ArgumentException("This method will not currently resolve other than IPv4 or IPv6 addresses");
 			}
 
 			// ok must be a host name
@@ -187,7 +187,7 @@ namespace Lidgren.Network
 					return null;
 				foreach (var address in addresses)
 				{
-					if (address.AddressFamily == AddressFamily.InterNetwork)
+					if (address.AddressFamily == AddressFamily.InterNetwork || ipAddress.AddressFamily == AddressFamily.InterNetworkV6)
 						return address;
 				}
 				return null;
@@ -451,5 +451,15 @@ namespace Lidgren.Network
 			// this is defined in the platform specific files
 			return ComputeSHAHash(bytes, 0, bytes.Length);
 		}
-	}
+
+        /// <summary>
+        /// Maps the IPEndPoint object to an IPv6 address, if it is currently mapped to an IPv4 address.
+        /// </summary>
+	    internal static IPEndPoint MapToIPv6(IPEndPoint endPoint) {
+	        if (endPoint.AddressFamily == AddressFamily.InterNetwork) {
+                return new IPEndPoint(endPoint.Address.MapToIPv6(), endPoint.Port);
+            }
+	        return endPoint;
+	    }
+    }
 }


### PR DESCRIPTION
Implements IPv6 Dual Mode as described in https://github.com/lidgren/lidgren-network-gen3/issues/32

My Visual Studio defaults use spaces instead of tabs. If you have an easy way to fix the affected lines please do so, otherwise I will fix that and create a new pull request.
