### PR TITLE
Different fixes caught by coverity

### DIFF
--- a/Lidgren.Network/NetConnectionStatistics.cs
+++ b/Lidgren.Network/NetConnectionStatistics.cs
@@ -171,7 +171,7 @@ namespace Lidgren.Network
 
 			if (m_resentMessagesDueToDelay > 0)
 				bdr.AppendLine("Resent messages (delay): " + m_resentMessagesDueToDelay);
-			if (m_resentMessagesDueToDelay > 0)
+			if (m_resentMessagesDueToHole > 0)
 				bdr.AppendLine("Resent messages (holes): " + m_resentMessagesDueToHole);
 
 			int numUnsent = 0;

--- a/Lidgren.Network/NetPeer.cs
+++ b/Lidgren.Network/NetPeer.cs
@@ -244,12 +244,20 @@ namespace Lidgren.Network
 			Recycle(msg);
 		}
 
+		static NetEndPoint GetNetEndPoint(string host, int port)
+		{
+			IPAddress address = NetUtility.Resolve(host);
+			if (address == null)
+				throw new NetException("Could not resolve host");
+			return new NetEndPoint(address, port);
+		}
+
 		/// <summary>
 		/// Create a connection to a remote endpoint
 		/// </summary>
 		public NetConnection Connect(string host, int port)
 		{
-			return Connect(new NetEndPoint(NetUtility.Resolve(host), port), null);
+			return Connect(GetNetEndPoint(host, port), null);
 		}
 
 		/// <summary>
@@ -257,7 +265,7 @@ namespace Lidgren.Network
 		/// </summary>
 		public NetConnection Connect(string host, int port, NetOutgoingMessage hailMessage)
 		{
-			return Connect(new NetEndPoint(NetUtility.Resolve(host), port), hailMessage);
+			return Connect(GetNetEndPoint(host, port), hailMessage);
 		}
 
 		/// <summary>

--- a/Lidgren.Network/NetPeerStatistics.cs
+++ b/Lidgren.Network/NetPeerStatistics.cs
@@ -105,7 +105,14 @@ namespace Lidgren.Network
 		/// <summary>
 		/// Gets the number of bytes in the recycled pool
 		/// </summary>
-		public int BytesInRecyclePool { get { return m_peer.m_storagePoolBytes; } }
+		public int BytesInRecyclePool
+		{
+			get
+			{
+				lock (m_peer.m_storagePool)
+					return m_peer.m_storagePoolBytes;
+			}
+		}
 
 #if !USE_RELEASE_STATISTICS
 		[Conditional("DEBUG")]

--- a/Lidgren.Network/NetQueue.cs
+++ b/Lidgren.Network/NetQueue.cs
@@ -56,12 +56,29 @@ namespace Lidgren.Network
 		/// <summary>
 		/// Gets the number of items in the queue
 		/// </summary>
-		public int Count { get { return m_size; } }
+		public int Count {
+			get
+			{
+				m_lock.EnterReadLock();
+				int count = m_size;
+				m_lock.ExitReadLock();
+				return count;
+			}
+		}
 
 		/// <summary>
 		/// Gets the current capacity for the queue
 		/// </summary>
-		public int Capacity { get { return m_items.Length; } }
+		public int Capacity
+		{
+			get
+			{
+				m_lock.EnterReadLock();
+				int capacity = m_items.Length;
+				m_lock.ExitReadLock();
+				return capacity;
+			}
+		}
 
 		/// <summary>
 		/// NetQueue constructor

--- a/Lidgren.Network/NetUPnP.cs
+++ b/Lidgren.Network/NetUPnP.cs
@@ -97,7 +97,9 @@ namespace Lidgren.Network
 			{
 #endif
 			XmlDocument desc = new XmlDocument();
-			desc.Load(WebRequest.Create(resp).GetResponse().GetResponseStream());
+			using (var response = WebRequest.Create(resp).GetResponse())
+				desc.Load(response.GetResponseStream());
+
 			XmlNamespaceManager nsMgr = new XmlNamespaceManager(desc.NameTable);
 			nsMgr.AddNamespace("tns", "urn:schemas-upnp-org:device-1-0");
 			XmlNode typen = desc.SelectSingleNode("//tns:device/tns:deviceType/text()", nsMgr);

--- a/Lidgren.Network/NetUPnP.cs
+++ b/Lidgren.Network/NetUPnP.cs
@@ -263,11 +263,12 @@ namespace Lidgren.Network
 			r.ContentType = "text/xml; charset=\"utf-8\"";
 			r.ContentLength = b.Length;
 			r.GetRequestStream().Write(b, 0, b.Length);
-			XmlDocument resp = new XmlDocument();
-			WebResponse wres = r.GetResponse();
-			Stream ress = wres.GetResponseStream();
-			resp.Load(ress);
-			return resp;
+			using (WebResponse wres = r.GetResponse()) {
+				XmlDocument resp = new XmlDocument();
+				Stream ress = wres.GetResponseStream();
+				resp.Load(ress);
+				return resp;
+			}
 		}
 	}
 }

--- a/Lidgren.Network/NetUtility.cs
+++ b/Lidgren.Network/NetUtility.cs
@@ -72,7 +72,7 @@ namespace Lidgren.Network
 		public static NetEndPoint Resolve(string ipOrHost, int port)
 		{
 			var adr = Resolve(ipOrHost);
-			return new NetEndPoint(adr, port);
+			return adr == null ? null : new NetEndPoint(adr, port);
 		}
 
 		private static IPAddress s_broadcastAddress;


### PR DESCRIPTION
Best reviewed commit by commit, as they're pretty atomic.

There are a few issues remaining that coverity unveiled, but I didn't touch since I don't have that much expertise in the repository's code.

Specifically, `NetQueue`'s `TryDrain` and `TryDequeue` are passible to having data races caused by the `m_size` checks.

`NetPeer.Internal.cs` seems to be deadlock-able. `m_handshakes` -> `m_connections` starting on line 655 conflicts with `NetPeer.Internal.cs` line 375 and line 249 which have `m_connections` -> `m_handshakes`.