### PR TITLE
Added a 64-bit version of ReadRangedInteger.

### DIFF
--- a/Lidgren.Network/NetBuffer.Read.cs
+++ b/Lidgren.Network/NetBuffer.Read.cs
@@ -548,6 +548,21 @@ namespace Lidgren.Network
 			return (int)(min + rvalue);
 		}
 
+	        /// <summary>
+	        /// Reads a 64 bit integer value written using WriteRangedInteger() (64 version)
+	        /// </summary>
+	        /// <param name="min">The minimum value used when writing the value</param>
+	        /// <param name="max">The maximum value used when writing the value</param>
+	        /// <returns>A signed integer value larger or equal to MIN and smaller or equal to MAX</returns>
+	        public long ReadRangedInteger(long min, long max)
+	        {
+	            ulong range = (ulong)(max - min);
+	            int numBits = NetUtility.BitsToHoldUInt64(range);
+	
+	            ulong rvalue = ReadUInt64(numBits);
+	            return min + (long)rvalue;
+	        }
+
 		/// <summary>
 		/// Reads a string written using Write(string)
 		/// </summary>


### PR DESCRIPTION
`public long ReadRangedInteger(long min, long max)` is now available for reads of LONG values.