### PR TITLE
WriteAt method and changes to work with Unity3D

### DIFF
--- a/Lidgren.Network/Encryption/NetAESEncryption.cs
+++ b/Lidgren.Network/Encryption/NetAESEncryption.cs
@@ -7,18 +7,30 @@ namespace Lidgren.Network
 	public class NetAESEncryption : NetCryptoProviderBase
 	{
 		public NetAESEncryption(NetPeer peer)
+#if UNITY
+			: base(peer, new RijndaelManaged())
+#else
 			: base(peer, new AesCryptoServiceProvider())
+#endif
 		{
 		}
 
 		public NetAESEncryption(NetPeer peer, string key)
+#if UNITY
+			: base(peer, new RijndaelManaged())
+#else
 			: base(peer, new AesCryptoServiceProvider())
+#endif
 		{
 			SetKey(key);
 		}
 
 		public NetAESEncryption(NetPeer peer, byte[] data, int offset, int count)
+#if UNITY
+			: base(peer, new RijndaelManaged())
+#else
 			: base(peer, new AesCryptoServiceProvider())
+#endif
 		{
 			SetKey(data, offset, count);
 		}

--- a/Lidgren.Network/NetBuffer.Write.cs
+++ b/Lidgren.Network/NetBuffer.Write.cs
@@ -102,6 +102,16 @@ namespace Lidgren.Network
 		}
 
 		/// <summary>
+		/// Writes a byte at a given offset in the buffer
+		/// </summary>
+		public void WriteAt(Int32 offset, byte source) {
+			int newBitLength = Math.Max(m_bitLength, offset + 8);
+			EnsureBufferSize(newBitLength);
+			NetBitWriter.WriteByte((byte) source, 8, m_data, offset);
+			m_bitLength = newBitLength;
+		}
+
+		/// <summary>
 		/// Writes a signed byte
 		/// </summary>
 		[CLSCompliant(false)]

--- a/Lidgren.Network/Platform/PlatformConstrained.cs
+++ b/Lidgren.Network/Platform/PlatformConstrained.cs
@@ -1,4 +1,4 @@
-﻿#if __CONSTRAINED__ || UNITY_STANDALONE_LINUX
+﻿#if __CONSTRAINED__ || UNITY_STANDALONE_LINUX || UNITY
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -29,9 +29,9 @@ namespace Lidgren.Network
 		public static IPAddress GetMyAddress(out IPAddress mask)
 		{
 			mask = null;
-#if UNITY_ANDROID || UNITY_STANDALONE_OSX || UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX || UNITY_IOS
 			try
 			{
+#if UNITY_ANDROID || UNITY_STANDALONE_OSX || UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX || UNITY_IOS || UNITY
 				if (!(UnityEngine.Application.internetReachability == UnityEngine.NetworkReachability.NotReachable))
 				{
 					return null;


### PR DESCRIPTION
I needed this methods to use less bandwith when sending an unknown number of objects:
WriteAt of Byte

Also there are some small changes to make Unity3d work again. I wrote in the wiki how to use this library with Unity but didn't send this changes (the tutorial, therefore, doesn't work). I forgot that the version of the library I am using is slightly different. :(

Thank you, I hope this helps!