### PR TITLE
Added improved NAT punch.

### DIFF
--- a/Lidgren.Network/NetMessageType.cs
+++ b/Lidgren.Network/NetMessageType.cs
@@ -169,6 +169,8 @@ namespace Lidgren.Network
 		DiscoveryResponse = 137,
 		NatPunchMessage = 138, // send between peers
 		NatIntroduction = 139, // send to master server
+		NatIntroductionConfirmRequest = 142,
+		NatIntroductionConfirmed = 143,
 		ExpandMTURequest = 140,
 		ExpandMTUSuccess = 141,
 	}

--- a/Lidgren.Network/NetPeer.Internal.cs
+++ b/Lidgren.Network/NetPeer.Internal.cs
@@ -120,7 +120,7 @@ namespace Lidgren.Network
 				m_socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
 
 			if (reBind)
-				m_socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, (int)1); 
+				m_socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, (int)1);
 
 			m_socket.ReceiveBufferSize = m_configuration.ReceiveBufferSize;
 			m_socket.SendBufferSize = m_configuration.SendBufferSize;
@@ -244,7 +244,7 @@ namespace Lidgren.Network
 			Heartbeat();
 
 			NetUtility.Sleep(10);
-			
+
 			lock (m_initializeLock)
 			{
 				try
@@ -412,7 +412,7 @@ namespace Lidgren.Network
 					switch (sx.SocketErrorCode)
 					{
 						case SocketError.ConnectionReset:
-							// connection reset by peer, aka connection forcibly closed aka "ICMP port unreachable" 
+							// connection reset by peer, aka connection forcibly closed aka "ICMP port unreachable"
 							// we should shut down the connection; but m_senderRemote seemingly cannot be trusted, so which connection should we shut down?!
 							// So, what to do?
 							LogWarning("ConnectionReset");
@@ -628,6 +628,14 @@ namespace Lidgren.Network
 				case NetMessageType.NatPunchMessage:
 					if (m_configuration.IsMessageTypeEnabled(NetIncomingMessageType.NatIntroductionSuccess))
 						HandleNatPunch(ptr, senderEndPoint);
+					return;
+				case NetMessageType.NatIntroductionConfirmRequest:
+					if (m_configuration.IsMessageTypeEnabled(NetIncomingMessageType.NatIntroductionSuccess))
+						HandleNatPunchConfirmRequest(ptr, senderEndPoint);
+					return;
+				case NetMessageType.NatIntroductionConfirmed:
+					if (m_configuration.IsMessageTypeEnabled(NetIncomingMessageType.NatIntroductionSuccess))
+						HandleNatPunchConfirmed(ptr, senderEndPoint);
 					return;
 				case NetMessageType.ConnectResponse:
 


### PR DESCRIPTION
Clients that request an introduction now first request a confirmation from
the server to make sure unconnected messages can be sent in both
directions before attempting to make a connection. Similarly the server
automatically sends a confirmation to the client to reduce the possiblity
that either one of the endpoints has issues with sending messages to the
other.