### PR TITLE
Fix random timed outs

### DIFF
--- a/Lidgren.Network/NetConnection.Latency.cs
+++ b/Lidgren.Network/NetConnection.Latency.cs
@@ -95,7 +95,7 @@ namespace Lidgren.Network
 				return;
 			}
 
-			m_timeoutDeadline = now + m_peerConfiguration.m_connectionTimeout;
+			ResetTimeout(now);
 
 			double rtt = now - m_sentPingTime;
 			NetException.Assert(rtt >= 0);

--- a/Lidgren.Network/NetConnection.cs
+++ b/Lidgren.Network/NetConnection.cs
@@ -123,7 +123,7 @@ namespace Lidgren.Network
 
 			if (m_status == NetConnectionStatus.Connected)
 			{
-				m_timeoutDeadline = NetTime.Now + m_peerConfiguration.m_connectionTimeout;
+				ResetTimeout(NetTime.Now);
 				m_peer.LogVerbose("Timeout deadline initialized to  " + m_timeoutDeadline);
 			}
 
@@ -488,6 +488,8 @@ namespace Lidgren.Network
 		internal void ReceivedMessage(NetIncomingMessage msg)
 		{
 			m_peer.VerifyNetworkThread();
+
+			ResetTimeout(NetTime.Now);
 
 			NetMessageType tp = msg.m_receivedMessageType;
 


### PR DESCRIPTION
This aims to fix the problem described here: https://github.com/lidgren/lidgren-network-gen3/issues/81
a peer can disconnect from other peer randomly by being timed out, even when there is traffic being transmited between them in that moment.
To solve it, the countdown to timeout is reset when traffic from the other peer comes through the method ReceivedMessage