### PR TITLE
Fix sending broadcast packets

### DIFF
--- a/Lidgren.Network/NetPeer.LatencySimulation.cs
+++ b/Lidgren.Network/NetPeer.LatencySimulation.cs
@@ -141,7 +141,7 @@ namespace Lidgren.Network
 				ba = NetUtility.GetCachedBroadcastAddress();
 
 				// TODO: refactor this check outta here
-				if (target.Address == ba)
+				if (target.Address.Equals(ba))
 				{
 					// Some networks do not allow 
 					// a global broadcast so we use the BroadcastAddress from the configuration


### PR DESCRIPTION
The `==` operator for IPAddress compares references not values, so `target.Address` will always not equal `ba`. Switching to `IPAddress.Equals` fixes this and allows broadcast packets to be sent on Linux.