### PR TITLE
additive-only multi-targeting support (.net 4.0 -> .net core 2.0)

### DIFF
--- a/Lidgren.Network.MultiTarget.sln
+++ b/Lidgren.Network.MultiTarget.sln
@@ -1,0 +1,65 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27428.2043
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lidgren.Network.MultiTarget", "Lidgren.Network.MultiTarget\Lidgren.Network.MultiTarget.csproj", "{B06120B6-880F-4DAE-9E42-A17C06E2B077}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests.Core", "UnitTests.Core\UnitTests.Core.csproj", "{A7E2B331-87EF-4D51-8D00-02AB08718483}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests.MultiTarget", "UnitTests.MultiTarget\UnitTests.MultiTarget.csproj", "{692C5016-356C-4FB0-AD7C-4B9801D14BBB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|Mixed Platforms = Debug|Mixed Platforms
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|Mixed Platforms = Release|Mixed Platforms
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B06120B6-880F-4DAE-9E42-A17C06E2B077}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B06120B6-880F-4DAE-9E42-A17C06E2B077}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B06120B6-880F-4DAE-9E42-A17C06E2B077}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{B06120B6-880F-4DAE-9E42-A17C06E2B077}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{B06120B6-880F-4DAE-9E42-A17C06E2B077}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B06120B6-880F-4DAE-9E42-A17C06E2B077}.Debug|x86.Build.0 = Debug|Any CPU
+		{B06120B6-880F-4DAE-9E42-A17C06E2B077}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B06120B6-880F-4DAE-9E42-A17C06E2B077}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B06120B6-880F-4DAE-9E42-A17C06E2B077}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{B06120B6-880F-4DAE-9E42-A17C06E2B077}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{B06120B6-880F-4DAE-9E42-A17C06E2B077}.Release|x86.ActiveCfg = Release|Any CPU
+		{B06120B6-880F-4DAE-9E42-A17C06E2B077}.Release|x86.Build.0 = Release|Any CPU
+		{A7E2B331-87EF-4D51-8D00-02AB08718483}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7E2B331-87EF-4D51-8D00-02AB08718483}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7E2B331-87EF-4D51-8D00-02AB08718483}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{A7E2B331-87EF-4D51-8D00-02AB08718483}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{A7E2B331-87EF-4D51-8D00-02AB08718483}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A7E2B331-87EF-4D51-8D00-02AB08718483}.Debug|x86.Build.0 = Debug|Any CPU
+		{A7E2B331-87EF-4D51-8D00-02AB08718483}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7E2B331-87EF-4D51-8D00-02AB08718483}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A7E2B331-87EF-4D51-8D00-02AB08718483}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{A7E2B331-87EF-4D51-8D00-02AB08718483}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{A7E2B331-87EF-4D51-8D00-02AB08718483}.Release|x86.ActiveCfg = Release|Any CPU
+		{A7E2B331-87EF-4D51-8D00-02AB08718483}.Release|x86.Build.0 = Release|Any CPU
+		{692C5016-356C-4FB0-AD7C-4B9801D14BBB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{692C5016-356C-4FB0-AD7C-4B9801D14BBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{692C5016-356C-4FB0-AD7C-4B9801D14BBB}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{692C5016-356C-4FB0-AD7C-4B9801D14BBB}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{692C5016-356C-4FB0-AD7C-4B9801D14BBB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{692C5016-356C-4FB0-AD7C-4B9801D14BBB}.Debug|x86.Build.0 = Debug|Any CPU
+		{692C5016-356C-4FB0-AD7C-4B9801D14BBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{692C5016-356C-4FB0-AD7C-4B9801D14BBB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{692C5016-356C-4FB0-AD7C-4B9801D14BBB}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{692C5016-356C-4FB0-AD7C-4B9801D14BBB}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{692C5016-356C-4FB0-AD7C-4B9801D14BBB}.Release|x86.ActiveCfg = Release|Any CPU
+		{692C5016-356C-4FB0-AD7C-4B9801D14BBB}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {46E2081A-758A-4FCB-99B8-CC718BA64C10}
+	EndGlobalSection
+EndGlobal

--- a/Lidgren.Network.MultiTarget/Lidgren.Network.MultiTarget.csproj
+++ b/Lidgren.Network.MultiTarget/Lidgren.Network.MultiTarget.csproj
@@ -1,0 +1,85 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net40;net45;net46;net461;net462;netstandard2.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Lidgren.Network\Encryption\NetAESEncryption.cs" Link="Encryption\NetAESEncryption.cs" />
+    <Compile Include="..\Lidgren.Network\Encryption\NetBlockEncryptionBase.cs" Link="Encryption\NetBlockEncryptionBase.cs" />
+    <Compile Include="..\Lidgren.Network\Encryption\NetCryptoProviderBase.cs" Link="Encryption\NetCryptoProviderBase.cs" />
+    <Compile Include="..\Lidgren.Network\Encryption\NetCryptoProviderEncryption.cs" Link="Encryption\NetCryptoProviderEncryption.cs" />
+    <Compile Include="..\Lidgren.Network\Encryption\NetDESEncryption.cs" Link="Encryption\NetDESEncryption.cs" />
+    <Compile Include="..\Lidgren.Network\Encryption\NetEncryption.cs" Link="Encryption\NetEncryption.cs" />
+    <Compile Include="..\Lidgren.Network\Encryption\NetRC2Encryption.cs" Link="Encryption\NetRC2Encryption.cs" />
+    <Compile Include="..\Lidgren.Network\Encryption\NetTripleDESEncryption.cs" Link="Encryption\NetTripleDESEncryption.cs" />
+    <Compile Include="..\Lidgren.Network\Encryption\NetXorEncryption.cs" Link="Encryption\NetXorEncryption.cs" />
+    <Compile Include="..\Lidgren.Network\Encryption\NetXteaEncryption.cs" Link="Encryption\NetXteaEncryption.cs" />
+    <Compile Include="..\Lidgren.Network\NamespaceDoc.cs" Link="NamespaceDoc.cs" />
+    <Compile Include="..\Lidgren.Network\NetBigInteger.cs" Link="NetBigInteger.cs" />
+    <Compile Include="..\Lidgren.Network\NetBitVector.cs" Link="NetBitVector.cs" />
+    <Compile Include="..\Lidgren.Network\NetBitWriter.cs" Link="NetBitWriter.cs" />
+    <Compile Include="..\Lidgren.Network\NetBuffer.cs" Link="NetBuffer.cs" />
+    <Compile Include="..\Lidgren.Network\NetBuffer.Peek.cs" Link="NetBuffer.Peek.cs" />
+    <Compile Include="..\Lidgren.Network\NetBuffer.Read.cs" Link="NetBuffer.Read.cs" />
+    <Compile Include="..\Lidgren.Network\NetBuffer.Read.Reflection.cs" Link="NetBuffer.Read.Reflection.cs" />
+    <Compile Include="..\Lidgren.Network\NetBuffer.Write.cs" Link="NetBuffer.Write.cs" />
+    <Compile Include="..\Lidgren.Network\NetBuffer.Write.Reflection.cs" Link="NetBuffer.Write.Reflection.cs" />
+    <Compile Include="..\Lidgren.Network\NetClient.cs" Link="NetClient.cs" />
+    <Compile Include="..\Lidgren.Network\NetConnection.cs" Link="NetConnection.cs" />
+    <Compile Include="..\Lidgren.Network\NetConnection.Handshake.cs" Link="NetConnection.Handshake.cs" />
+    <Compile Include="..\Lidgren.Network\NetConnection.Latency.cs" Link="NetConnection.Latency.cs" />
+    <Compile Include="..\Lidgren.Network\NetConnection.MTU.cs" Link="NetConnection.MTU.cs" />
+    <Compile Include="..\Lidgren.Network\NetConnectionStatistics.cs" Link="NetConnectionStatistics.cs" />
+    <Compile Include="..\Lidgren.Network\NetConnectionStatus.cs" Link="NetConnectionStatus.cs" />
+    <Compile Include="..\Lidgren.Network\NetConstants.cs" Link="NetConstants.cs" />
+    <Compile Include="..\Lidgren.Network\NetDeliveryMethod.cs" Link="NetDeliveryMethod.cs" />
+    <Compile Include="..\Lidgren.Network\NetException.cs" Link="NetException.cs" />
+    <Compile Include="..\Lidgren.Network\NetFragmentationHelper.cs" Link="NetFragmentationHelper.cs" />
+    <Compile Include="..\Lidgren.Network\NetFragmentationInfo.cs" Link="NetFragmentationInfo.cs" />
+    <Compile Include="..\Lidgren.Network\NetIncomingMessage.cs" Link="NetIncomingMessage.cs" />
+    <Compile Include="..\Lidgren.Network\NetIncomingMessageType.cs" Link="NetIncomingMessageType.cs" />
+    <Compile Include="..\Lidgren.Network\NetMessageType.cs" Link="NetMessageType.cs" />
+    <Compile Include="..\Lidgren.Network\NetNatIntroduction.cs" Link="NetNatIntroduction.cs" />
+    <Compile Include="..\Lidgren.Network\NetOutgoingMessage.cs" Link="NetOutgoingMessage.cs" />
+    <Compile Include="..\Lidgren.Network\NetPeer.cs" Link="NetPeer.cs" />
+    <Compile Include="..\Lidgren.Network\NetPeer.Discovery.cs" Link="NetPeer.Discovery.cs" />
+    <Compile Include="..\Lidgren.Network\NetPeer.Fragmentation.cs" Link="NetPeer.Fragmentation.cs" />
+    <Compile Include="..\Lidgren.Network\NetPeer.Internal.cs" Link="NetPeer.Internal.cs" />
+    <Compile Include="..\Lidgren.Network\NetPeer.LatencySimulation.cs" Link="NetPeer.LatencySimulation.cs" />
+    <Compile Include="..\Lidgren.Network\NetPeer.Logging.cs" Link="NetPeer.Logging.cs" />
+    <Compile Include="..\Lidgren.Network\NetPeer.MessagePools.cs" Link="NetPeer.MessagePools.cs" />
+    <Compile Include="..\Lidgren.Network\NetPeer.Send.cs" Link="NetPeer.Send.cs" />
+    <Compile Include="..\Lidgren.Network\NetPeerConfiguration.cs" Link="NetPeerConfiguration.cs" />
+    <Compile Include="..\Lidgren.Network\NetPeerStatistics.cs" Link="NetPeerStatistics.cs" />
+    <Compile Include="..\Lidgren.Network\NetPeerStatus.cs" Link="NetPeerStatus.cs" />
+    <Compile Include="..\Lidgren.Network\NetQueue.cs" Link="NetQueue.cs" />
+    <Compile Include="..\Lidgren.Network\NetRandom.cs" Link="NetRandom.cs" />
+    <Compile Include="..\Lidgren.Network\NetRandom.Implementations.cs" Link="NetRandom.Implementations.cs" />
+    <Compile Include="..\Lidgren.Network\NetRandomSeed.cs" Link="NetRandomSeed.cs" />
+    <Compile Include="..\Lidgren.Network\NetReceiverChannelBase.cs" Link="NetReceiverChannelBase.cs" />
+    <Compile Include="..\Lidgren.Network\NetReliableOrderedReceiver.cs" Link="NetReliableOrderedReceiver.cs" />
+    <Compile Include="..\Lidgren.Network\NetReliableSenderChannel.cs" Link="NetReliableSenderChannel.cs" />
+    <Compile Include="..\Lidgren.Network\NetReliableSequencedReceiver.cs" Link="NetReliableSequencedReceiver.cs" />
+    <Compile Include="..\Lidgren.Network\NetReliableUnorderedReceiver.cs" Link="NetReliableUnorderedReceiver.cs" />
+    <Compile Include="..\Lidgren.Network\NetSenderChannelBase.cs" Link="NetSenderChannelBase.cs" />
+    <Compile Include="..\Lidgren.Network\NetSendResult.cs" Link="NetSendResult.cs" />
+    <Compile Include="..\Lidgren.Network\NetServer.cs" Link="NetServer.cs" />
+    <Compile Include="..\Lidgren.Network\NetSRP.cs" Link="NetSRP.cs" />
+    <Compile Include="..\Lidgren.Network\NetStoredReliableMessage.cs" Link="NetStoredReliableMessage.cs" />
+    <Compile Include="..\Lidgren.Network\NetTime.cs" Link="NetTime.cs" />
+    <Compile Include="..\Lidgren.Network\NetTuple.cs" Link="NetTuple.cs" />
+    <Compile Include="..\Lidgren.Network\NetUnreliableSenderChannel.cs" Link="NetUnreliableSenderChannel.cs" />
+    <Compile Include="..\Lidgren.Network\NetUnreliableSequencedReceiver.cs" Link="NetUnreliableSequencedReceiver.cs" />
+    <Compile Include="..\Lidgren.Network\NetUnreliableUnorderedReceiver.cs" Link="NetUnreliableUnorderedReceiver.cs" />
+    <Compile Include="..\Lidgren.Network\NetUPnP.cs" Link="NetUPnP.cs" />
+    <Compile Include="..\Lidgren.Network\NetUtility.cs" Link="NetUtility.cs" />
+    <Compile Include="..\Lidgren.Network\Platform\PlatformWin32.cs" Link="Platform\PlatformWin32.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Encryption\" />
+    <Folder Include="Platform\" />
+  </ItemGroup>
+
+</Project>

--- a/UnitTests.Core/UnitTests.Core.csproj
+++ b/UnitTests.Core/UnitTests.Core.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\UnitTests\BitVectorTests.cs" Link="BitVectorTests.cs" />
+    <Compile Include="..\UnitTests\EncryptionTests.cs" Link="EncryptionTests.cs" />
+    <Compile Include="..\UnitTests\MiscTests.cs" Link="MiscTests.cs" />
+    <Compile Include="..\UnitTests\NetQueueTests.cs" Link="NetQueueTests.cs" />
+    <Compile Include="..\UnitTests\Program.cs" Link="Program.cs" />
+    <Compile Include="..\UnitTests\ReadWriteTests.cs" Link="ReadWriteTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Lidgren.Network.MultiTarget\Lidgren.Network.MultiTarget.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/UnitTests.MultiTarget/App.config
+++ b/UnitTests.MultiTarget/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    </startup>
+</configuration>

--- a/UnitTests.MultiTarget/Properties/AssemblyInfo.cs
+++ b/UnitTests.MultiTarget/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("UnitTests.MultiTarget")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("UnitTests.MultiTarget")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("692c5016-356c-4fb0-ad7c-4b9801d14bbb")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/UnitTests.MultiTarget/UnitTests.MultiTarget.csproj
+++ b/UnitTests.MultiTarget/UnitTests.MultiTarget.csproj
@@ -1,0 +1,75 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{692C5016-356C-4FB0-AD7C-4B9801D14BBB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>UnitTests.MultiTarget</RootNamespace>
+    <AssemblyName>UnitTests.MultiTarget</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\UnitTests\BitVectorTests.cs">
+      <Link>BitVectorTests.cs</Link>
+    </Compile>
+    <Compile Include="..\UnitTests\EncryptionTests.cs">
+      <Link>EncryptionTests.cs</Link>
+    </Compile>
+    <Compile Include="..\UnitTests\MiscTests.cs">
+      <Link>MiscTests.cs</Link>
+    </Compile>
+    <Compile Include="..\UnitTests\NetQueueTests.cs">
+      <Link>NetQueueTests.cs</Link>
+    </Compile>
+    <Compile Include="..\UnitTests\Program.cs">
+      <Link>Program.cs</Link>
+    </Compile>
+    <Compile Include="..\UnitTests\ReadWriteTests.cs">
+      <Link>ReadWriteTests.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Lidgren.Network.MultiTarget\Lidgren.Network.MultiTarget.csproj">
+      <Project>{b06120b6-880f-4dae-9e42-a17c06e2b077}</Project>
+      <Name>Lidgren.Network.MultiTarget</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
These SLN/csproj files will compile lidgren to multi-target .NET 4.0/.NET 4.6/.NET 4.6.1/.NET 4.6.2/.NET Standard 2.0, so it can run in .NET Core. Unit tests have also been ported and run in both .NET 4.6 (original but pointing to the multi-target build) and .NET Core 2.0