### PR TITLE
Fixed NetServer missing SendToAll override with sequence channel parameter

### DIFF
--- a/Lidgren.Network/NetServer.cs
+++ b/Lidgren.Network/NetServer.cs
@@ -36,6 +36,25 @@ namespace Lidgren.Network
 		}
 
 		/// <summary>
+		/// Send a message to all connections
+		/// </summary>
+		/// <param name="msg">The message to send</param>
+		/// <param name="method">How to deliver the message</param>
+		/// <param name="sequenceChannel">Which sequence channel to use for the message</param>
+		public void SendToAll(NetOutgoingMessage msg, NetDeliveryMethod method, int sequenceChannel)
+		{
+			// Modifying m_connections will modify the list of the connections of the NetPeer. Do only reads here
+			var all = m_connections;
+			if (all.Count <= 0) {
+				if (msg.m_isSent == false)
+					Recycle(msg);
+				return;
+			}
+
+			SendMessage(msg, all, method, sequenceChannel);
+		}
+
+		/// <summary>
 		/// Send a message to all connections except one
 		/// </summary>
 		/// <param name="msg">The message to send</param>


### PR DESCRIPTION
The only SendToAll method that accepted a sequence channel was the override that allows you to skip a NetConnection (which you could pass null to get the same result as this change - but this skips the performance cost of doing that).