### PR TITLE
Fix: Connection.Connect() now correctly updates the Connection.Status…

### DIFF
--- a/Lidgren.Network/NetPeer.cs
+++ b/Lidgren.Network/NetPeer.cs
@@ -335,7 +335,7 @@ namespace Lidgren.Network
 				}
 
 				NetConnection conn = new NetConnection(this, remoteEndPoint);
-				conn.m_status = NetConnectionStatus.InitiatedConnect;
+                conn.SetStatus(NetConnectionStatus.InitiatedConnect, "user called connect");
 				conn.m_localHailMessage = hailMessage;
 
 				// handle on network thread


### PR DESCRIPTION
Fix: Connection.Connect() now correctly updates the Connection.Status property when needed.

Previously, it would never update it, even when users had opted to not receive status update change messages.
It now properly calls SetStatus() instead of modifying the m_status field directly.

This fixes issue #117.
