### PR TITLE
Fixed bugs after introducing IPv6 dual mode

### DIFF
--- a/Lidgren.Network/NetPeer.Internal.cs
+++ b/Lidgren.Network/NetPeer.Internal.cs
@@ -135,7 +135,11 @@ namespace Lidgren.Network
                     if(m_configuration.DualStack && m_configuration.LocalAddress.AddressFamily == AddressFamily.InterNetworkV6)
                         m_socket.DualMode = true;
 
-					var ep = (EndPoint)new NetEndPoint(m_configuration.LocalAddress.MapToIPv6(), reBind ? m_listenPort : m_configuration.Port);
+                    var localAddress = m_configuration.DualStack
+                        ? m_configuration.LocalAddress.MapToIPv6()
+                        : m_configuration.LocalAddress;
+
+                    var ep = (EndPoint)new NetEndPoint(localAddress, reBind ? m_listenPort : m_configuration.Port);
 					m_socket.Bind(ep);
 
 					try

--- a/Lidgren.Network/NetPeer.LatencySimulation.cs
+++ b/Lidgren.Network/NetPeer.LatencySimulation.cs
@@ -155,6 +155,11 @@ namespace Lidgren.Network
                 }
                 else if(m_configuration.DualStack && m_configuration.LocalAddress.AddressFamily == AddressFamily.InterNetworkV6)
                     NetUtility.CopyEndpoint(target, targetCopy); //Maps to IPv6 for Dual Mode
+                else
+                {
+	                targetCopy.Port = target.Port;
+	                targetCopy.Address = target.Address;
+                }
 
                 int bytesSent = m_socket.SendTo(data, 0, numBytes, SocketFlags.None, targetCopy);
 				if (numBytes != bytesSent)

--- a/Lidgren.Network/NetPeer.cs
+++ b/Lidgren.Network/NetPeer.cs
@@ -121,7 +121,8 @@ namespace Lidgren.Network
 			m_connections = new List<NetConnection>();
 			m_connectionLookup = new Dictionary<NetEndPoint, NetConnection>();
 			m_handshakes = new Dictionary<NetEndPoint, NetConnection>();
-			m_senderRemote = (EndPoint)new NetEndPoint(IPAddress.IPv6Any, 0);
+            var address = config.DualStack ? IPAddress.IPv6Any : IPAddress.Any;
+            m_senderRemote = (EndPoint)new NetEndPoint(address, 0);
 			m_status = NetPeerStatus.NotRunning;
 			m_receivedFragmentGroups = new Dictionary<NetConnection, Dictionary<int, ReceivedFragmentGroup>>();	
 		}

--- a/Lidgren.Network/NetPeerConfiguration.cs
+++ b/Lidgren.Network/NetPeerConfiguration.cs
@@ -95,7 +95,7 @@ namespace Lidgren.Network
 			//
 			m_disabledTypes = NetIncomingMessageType.ConnectionApproval | NetIncomingMessageType.UnconnectedData | NetIncomingMessageType.VerboseDebugMessage | NetIncomingMessageType.ConnectionLatencyUpdated | NetIncomingMessageType.NatIntroductionSuccess;
 			m_networkThreadName = "Lidgren network thread";
-			m_localAddress = IPAddress.IPv6Any;
+			m_localAddress = IPAddress.Any;
 			m_broadcastAddress = IPAddress.Broadcast;
 			var ip = NetUtility.GetBroadcastAddress();
 			if (ip != null)
@@ -330,7 +330,7 @@ namespace Lidgren.Network
 		}
 
 		/// <summary>
-		/// Gets or sets the local ip address to bind to. Defaults to IPAddress.IPv6Any. Cannot be changed once NetPeer is initialized.
+		/// Gets or sets the local ip address to bind to. Defaults to IPAddress.Any. Cannot be changed once NetPeer is initialized.
 		/// </summary>
 		public IPAddress LocalAddress
 		{
@@ -354,6 +354,10 @@ namespace Lidgren.Network
                 if (m_isLocked)
                     throw new NetException(c_isLockedMessage);
                 m_dualStack = value;
+                if (m_dualStack && m_localAddress.Equals(IPAddress.Any))
+                    m_localAddress = IPAddress.IPv6Any;
+                if (!m_dualStack && m_localAddress.Equals(IPAddress.IPv6Any))
+                    m_localAddress = IPAddress.Any;
             }
         }
 

--- a/Lidgren.Network/NetUtility.cs
+++ b/Lidgren.Network/NetUtility.cs
@@ -189,7 +189,7 @@ namespace Lidgren.Network
 					return null;
 				foreach (var address in addresses)
 				{
-					if (address.AddressFamily == AddressFamily.InterNetwork || ipAddress.AddressFamily == AddressFamily.InterNetworkV6)
+					if (address.AddressFamily == AddressFamily.InterNetwork || address.AddressFamily == AddressFamily.InterNetworkV6)
 						return address;
 				}
 				return null;


### PR DESCRIPTION
This pull request fixes a couple of bugs introduced in https://github.com/lidgren/lidgren-network-gen3/pull/123:
- null ref exception when we try to use host name instead of actual IP
- wrong target IP address when we are not using IPv6 dual mode

