### PR TITLE
Improve multi-target csproj.

### DIFF
--- a/Lidgren.Network.MultiTarget/Lidgren.Network.MultiTarget.csproj
+++ b/Lidgren.Network.MultiTarget/Lidgren.Network.MultiTarget.csproj
@@ -1,10 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;net46;net461;net462;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;net46;net461;net462;netstandard2.0</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Lidgren.Network\Properties\AssemblyInfo.cs" Link="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Lidgren.Network\Encryption\NetAESEncryption.cs" Link="Encryption\NetAESEncryption.cs" />
     <Compile Include="..\Lidgren.Network\Encryption\NetBlockEncryptionBase.cs" Link="Encryption\NetBlockEncryptionBase.cs" />
     <Compile Include="..\Lidgren.Network\Encryption\NetCryptoProviderBase.cs" Link="Encryption\NetCryptoProviderBase.cs" />
@@ -80,6 +82,13 @@
   <ItemGroup>
     <Folder Include="Encryption\" />
     <Folder Include="Platform\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
1. Added a reference to Microsoft.NETFramework.ReferenceAssemblies so that the project can be built hassle-free on .NET Core.
2. Use the AssemblyInfo.cs from the existing code and disable automatic AssemblyInfo generation (to avoid clash).
3. Dropped target for net40. The regular Framework project file didn't support it either and it doesn't build due to a missing API (MapToIPv6).