### PR TITLE
Fixed errors with discovery when using IPv6

### DIFF
--- a/Lidgren.Network/NetPeer.Discovery.cs
+++ b/Lidgren.Network/NetPeer.Discovery.cs
@@ -21,8 +21,8 @@ namespace Lidgren.Network
 			Interlocked.Increment(ref um.m_recyclingCount);
 
 			var broadcastAddress = NetUtility.GetBroadcastAddress();
-			if (this.Configuration.LocalAddress.AddressFamily == AddressFamily.InterNetworkV6)
-				broadcastAddress = broadcastAddress.MapToIPv6();
+			if (m_configuration.DualStack)
+				broadcastAddress = NetUtility.MapToIPv6(broadcastAddress);
 
 			m_unsentUnconnectedMessages.Enqueue(new NetTuple<NetEndPoint, NetOutgoingMessage>(new NetEndPoint(broadcastAddress, serverPort), um));
 		}

--- a/Lidgren.Network/NetPeer.Discovery.cs
+++ b/Lidgren.Network/NetPeer.Discovery.cs
@@ -44,6 +44,11 @@ namespace Lidgren.Network
 		/// </summary>
 		public void DiscoverKnownPeer(NetEndPoint endPoint)
 		{
+			if (endPoint == null)
+				throw new ArgumentNullException(nameof(endPoint));
+			if (m_configuration.DualStack)
+				endPoint = NetUtility.MapToIPv6(endPoint);
+
 			NetOutgoingMessage om = CreateMessage(0);
 			om.m_messageType = NetMessageType.Discovery;
 			om.m_recyclingCount = 1;

--- a/Lidgren.Network/NetPeer.Discovery.cs
+++ b/Lidgren.Network/NetPeer.Discovery.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 
 #if !__NOIPENDPOINT__
@@ -19,7 +20,11 @@ namespace Lidgren.Network
 			um.m_messageType = NetMessageType.Discovery;
 			Interlocked.Increment(ref um.m_recyclingCount);
 
-			m_unsentUnconnectedMessages.Enqueue(new NetTuple<NetEndPoint, NetOutgoingMessage>(new NetEndPoint(NetUtility.GetBroadcastAddress(), serverPort), um));
+			var broadcastAddress = NetUtility.GetBroadcastAddress();
+			if (this.Configuration.LocalAddress.AddressFamily == AddressFamily.InterNetworkV6)
+				broadcastAddress = broadcastAddress.MapToIPv6();
+
+			m_unsentUnconnectedMessages.Enqueue(new NetTuple<NetEndPoint, NetOutgoingMessage>(new NetEndPoint(broadcastAddress, serverPort), um));
 		}
 
 		/// <summary>

--- a/Lidgren.Network/NetUtility.cs
+++ b/Lidgren.Network/NetUtility.cs
@@ -489,5 +489,15 @@ namespace Lidgren.Network
                 return new IPEndPoint(endPoint.Address.MapToIPv6(), endPoint.Port);
             return endPoint;
         }
+
+        /// <summary>
+        /// Maps the IPAddress object to an IPv6 address. Has allocation
+        /// </summary>
+        internal static IPAddress MapToIPv6(IPAddress address)
+        {
+            if (address.AddressFamily == AddressFamily.InterNetwork)
+                return address.MapToIPv6();
+            return address;
+        }
     }
 }


### PR DESCRIPTION
Previously if you called `NetPeer.DiscoverLocalPeers()` when the NetPeer is using IPv6, you'd get a SocketException about pointers in the wrong place. This fixes the bug by mapping the broadcast address to IPv6 when the peer is using IPv6.

CC @PJB3005, who originally wrote the IPv6 support in #136 .